### PR TITLE
fix(docs): Remove MTU settings from docs

### DIFF
--- a/docs/docs/tweaks/optimize-network-settings.md
+++ b/docs/docs/tweaks/optimize-network-settings.md
@@ -31,8 +31,6 @@ netsh int tcp set global timestamps=disabled
 netsh int tcp set global fastopen=enabled
 netsh int tcp set global fastopenfallback=enabled
 netsh int tcp set supplemental template=custom icw=10
-netsh interface ipv4 set subinterface "Wi-Fi" mtu=1500 store=persistent
-netsh interface ipv4 set subinterface Ethernet mtu=1500 store=persistent
 
 Write-Host "Network tweaks applied successfully."
 
@@ -51,8 +49,6 @@ netsh int tcp set global timestamps=default
 netsh int tcp set global fastopen=default
 netsh int tcp set global fastopenfallback=default
 netsh int tcp set supplemental template=custom icw=4
-netsh interface ipv4 set subinterface "Wi-Fi" mtu=1500 store=persistent
-netsh interface ipv4 set subinterface Ethernet mtu=1500 store=persistent
 
 Write-Host "Network tweaks reverted to defaults."
 


### PR DESCRIPTION
Removed MTU settings for Wi-Fi and Ethernet interfaces from both the apply and revert sections in the documentation.

Closes #83