### PR TITLE
feat: Remove system info from homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ irm https://raw.githubusercontent.com/Parcoil/Sparkle/v2/get.ps1 | iex
     <li>🗑️ Manage All Temp files in one place</li>
     <li>🎛️ Install apps with the built-in Winget integration</li>
     <li>📁 Backup and Revert changes</li>
-    <li>⚙️ View Basic System info</li>
   </ul>
 </div>
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,6 @@ import { electronApp, optimizer, is } from "@electron-toolkit/utils"
 import log from "electron-log"
 import "./system"
 import "./powershell"
-
 import "./tweakHandler"
 import "./dnsHandler"
 import "./backup"

--- a/src/main/system.ts
+++ b/src/main/system.ts
@@ -1,26 +1,15 @@
 import os from "os"
 import { ipcMain } from "electron"
-import si from "systeminformation"
 import { exec } from "child_process"
 import fs from "fs"
 import path from "path"
 import log from "electron-log"
 import { shell } from "electron"
 import { executePowerShell } from "./powershell"
-import type { SystemInfo } from "../types"
 
 console.log = log.log
 console.error = log.error
 console.warn = log.warn
-
-interface GPUInfo {
-  model: string
-  vram: string
-  hasGPU: boolean
-  isNvidia: boolean
-  integratedModel: string
-  hasIntegratedGPU: boolean
-}
 
 interface PowerShellResult {
   success: boolean
@@ -31,146 +20,6 @@ interface PowerShellResult {
 interface ClearCacheResult {
   success: boolean
   error?: string
-}
-
-async function getSystemInfo(): Promise<SystemInfo> {
-  try {
-    const [cpuData, graphicsData, osInfo, memLayout, diskLayout, fsSize, blockDevices] =
-      await Promise.all([
-        si.cpu(),
-        si.graphics(),
-        si.osInfo(),
-        si.memLayout(),
-        si.diskLayout(),
-        si.fsSize(),
-        si.blockDevices(),
-      ])
-
-    let totalMemory = os.totalmem()
-    const memoryType = (memLayout as any).length > 0 ? (memLayout as any)[0].type : "Unknown"
-    const cDrive = (fsSize as any).find((d: any) => d.mount.toUpperCase().startsWith("C:"))
-
-    let primaryDisk: any = null
-    if (cDrive) {
-      const cBlock = (blockDevices as any).find(
-        (b: any) => b.mount && b.mount.toUpperCase().startsWith("C:"),
-      )
-
-      if (cBlock) {
-        primaryDisk =
-          (diskLayout as any).find(
-            (disk: any) =>
-              disk.device?.toLowerCase() === cBlock.device?.toLowerCase() ||
-              disk.name?.toLowerCase().includes(cBlock.name?.toLowerCase()),
-          ) || null
-      }
-    }
-
-    let gpuInfo: GPUInfo = {
-      model: "GPU not found",
-      vram: "N/A",
-      hasGPU: false,
-      isNvidia: false,
-      integratedModel: "Not detected",
-      hasIntegratedGPU: false,
-    }
-
-    if (graphicsData.controllers && graphicsData.controllers.length > 0) {
-      const integratedControllers = graphicsData.controllers.filter((controller: any) => {
-        const model = (controller.model || "").toLowerCase()
-        return (
-          model.includes("integrated") ||
-          (model.includes("intel") &&
-            (model.includes("hd") || model.includes("uhd") || model.includes("iris"))) ||
-          (model.includes("amd") && model.includes("radeon") && model.includes("graphics")) ||
-          (model.includes("amd") && model.includes("vega") && !model.includes("rx")) ||
-          model.includes("intel graphics")
-        )
-      })
-
-      const dedicatedControllers = graphicsData.controllers.filter((controller: any) => {
-        const model = (controller.model || "").toLowerCase()
-        const isIntegrated =
-          model.includes("integrated") ||
-          (model.includes("intel") &&
-            (model.includes("hd") || model.includes("uhd") || model.includes("iris"))) ||
-          (model.includes("amd") && model.includes("radeon") && model.includes("graphics")) ||
-          (model.includes("amd") && model.includes("vega") && !model.includes("rx")) ||
-          model.includes("intel graphics")
-
-        return (
-          !isIntegrated &&
-          (model.includes("nvidia") ||
-            (model.includes("amd") &&
-              (model.includes("radeon") ||
-                model.includes("rx") ||
-                model.includes("vega") ||
-                model.includes("firepro") ||
-                model.includes("instinct"))) ||
-            (model.includes("intel") && model.includes("arc")))
-        )
-      })
-
-      const dedicatedGPU = dedicatedControllers.sort(
-        (a: any, b: any) => (b.vram || 0) - (a.vram || 0),
-      )[0]
-
-      const integratedGPU = integratedControllers.sort(
-        (a: any, b: any) => (b.vram || 0) - (a.vram || 0),
-      )[0]
-
-      if (integratedGPU) {
-        gpuInfo.integratedModel = integratedGPU.model || "Unknown Integrated GPU"
-        gpuInfo.hasIntegratedGPU = true
-      }
-
-      if (dedicatedGPU) {
-        const hasGPU = true
-        const isNvidia = dedicatedGPU.model.toLowerCase().includes("nvidia")
-        gpuInfo = {
-          ...gpuInfo,
-          model: dedicatedGPU.model || "Unknown GPU",
-          vram: dedicatedGPU.vram ? `${Math.round(dedicatedGPU.vram / 1024)} GB` : "Unknown",
-          hasGPU,
-          isNvidia,
-        }
-      }
-    }
-
-    const versionScript = `(Get-ItemProperty -Path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion").DisplayVersion`
-    const versionPsResult = await executePowerShell(null, {
-      script: versionScript,
-      name: "GetWindowsVersion",
-    })
-    const windowsVersion = versionPsResult.success ? versionPsResult.output!.trim() : "Unknown"
-
-    return {
-      cpu_model: (cpuData as any).brand,
-      cpu_cores: (cpuData as any).physicalCores,
-      cpu_threads: (cpuData as any).threads || (cpuData as any).physicalCores,
-
-      gpu_model: gpuInfo.model,
-      vram: gpuInfo.vram,
-      hasGPU: gpuInfo.hasGPU,
-      isNvidia: gpuInfo.isNvidia,
-      integrated_gpu: gpuInfo.integratedModel,
-      hasIntegratedGPU: gpuInfo.hasIntegratedGPU,
-
-      memory_total: totalMemory,
-      memory_type: memoryType,
-
-      os: osInfo.distro || "Windows",
-      os_version: windowsVersion || "Unknown",
-
-      disk_model: primaryDisk?.name || primaryDisk?.device || "Unknown Storage",
-      disk_size: cDrive?.size
-        ? `${Math.round(cDrive.size / 1024 / 1024 / 1024).toFixed(1)} GB`
-        : "Unknown",
-    }
-  } catch (error) {
-    console.error("Failed to get system info:", error)
-    throw error
-  }
 }
 
 function restartSystem(): { success: boolean } {
@@ -523,7 +372,6 @@ export { ensureWinget }
 ipcMain.handle("restart", restartSystem)
 ipcMain.handle("open-log-folder", openLogFolder)
 ipcMain.handle("clear-sparkle-cache", clearSparkleCache)
-ipcMain.handle("get-system-info", getSystemInfo)
 ipcMain.handle("get-user-name", getUserName)
 ipcMain.handle("restart-explorer", restartExplorer)
 ipcMain.handle("check-winget", async () => {

--- a/src/renderer/src/components/nav.tsx
+++ b/src/renderer/src/components/nav.tsx
@@ -33,7 +33,7 @@ const tabIcons = {
 }
 
 const tabs = {
-  home: { label: "Dashboard", path: "/" },
+  home: { label: "Home", path: "/" },
   tweaks: { label: "Tweaks", path: "/tweaks" },
   utilities: { label: "Utilities", path: "/utilities" },
   clean: { label: "Cleaner", path: "/clean" },

--- a/src/renderer/src/components/titlebar.tsx
+++ b/src/renderer/src/components/titlebar.tsx
@@ -14,7 +14,7 @@ function TitleBar({
   return (
     <div
       style={{ WebkitAppRegion: "drag" } as any}
-      className="h-[50px] fixed top-0 left-0 right-0 flex justify-between items-center pl-4 bg-sparkle-bg z-50"
+      className="h-12.5 fixed top-0 left-0 right-0 flex justify-between items-center pl-4 bg-sparkle-bg z-50"
     >
       <div className="flex items-center gap-3 h-full pr-4">
         <button

--- a/src/renderer/src/pages/Home.tsx
+++ b/src/renderer/src/pages/Home.tsx
@@ -1,245 +1,109 @@
-import { useState, useEffect } from "react"
 import RootDiv from "@/components/rootdiv"
-import { Cpu, HardDrive, Zap, MemoryStick, Gpu } from "lucide-react"
-import InfoCard from "@/components/infocard"
-import { invoke } from "@/lib/electron"
+import { Zap, Wrench, ExternalLink, Shield, Cpu, Box, LayoutGrid } from "lucide-react"
 import Button from "@/components/ui/button"
 import { useNavigate } from "react-router-dom"
-import useSystemStore from "@/store/systemInfo"
-import log from "electron-log/renderer"
-import Greeting from "@/components/greeting"
-import { MonitorCog } from "lucide-react"
-import { Wrench } from "lucide-react"
 import Card from "@/components/ui/Card"
+
 function Home() {
-  const systemInfo = useSystemStore((state) => state.systemInfo)
-  const setSystemInfo = useSystemStore((state) => state.setSystemInfo)
-  const [tweakInfo, setTweakInfo] = useState(() => {
-    try {
-      const cached = localStorage.getItem("sparkle:tweakInfo")
-      return cached ? JSON.parse(cached) : null
-    } catch (err) {
-      console.error("Failed to parse tweakInfo cache", err)
-      return null
-    }
-  })
   const router = useNavigate()
-  const [loading, setLoading] = useState(true)
-  const [usingCache, setUsingCache] = useState(false)
-  const [activeTweaks, setActiveTweaks] = useState(() => {
-    try {
-      const cached = localStorage.getItem("sparkle:activeTweaks")
-      return cached ? JSON.parse(cached) : []
-    } catch {
-      return []
-    }
-  })
-
-  const goToTweaks = () => {
-    router("tweaks")
-  }
-
-  const fetchActiveTweaks = async () => {
-    try {
-      const active = await invoke({ channel: "tweak:active" })
-      setActiveTweaks(active)
-      localStorage.setItem("sparkle:activeTweaks", JSON.stringify(active))
-    } catch (err) {
-      console.error("Failed to fetch active tweaks:", err)
-    }
-  }
-
-  useEffect(() => {
-    const idleHandle = requestIdleCallback(() => {
-      const cached = localStorage.getItem("sparkle:systemInfo")
-      if (cached) {
-        try {
-          const parsed = JSON.parse(cached)
-          setSystemInfo(parsed)
-          setUsingCache(true)
-          setLoading(false)
-        } catch (err) {
-          console.warn("Failed to parse systemInfo cache", err)
-        }
-      }
-
-      invoke({ channel: "get-system-info" })
-        .then((info) => {
-          setSystemInfo(info)
-          localStorage.setItem("sparkle:systemInfo", JSON.stringify(info))
-          setUsingCache(false)
-          log.info("Fetched system info")
-        })
-        .catch((err) => {
-          log.error("Error fetching system info:", err)
-          console.error("Error fetching system info:", err)
-        })
-        .finally(() => setLoading(false))
-    })
-
-    return () => cancelIdleCallback(idleHandle)
-  }, [])
-
-  useEffect(() => {
-    const idleHandle = requestIdleCallback(() => {
-      const cached = localStorage.getItem("sparkle:tweakInfo")
-      if (cached) {
-        try {
-          setTweakInfo(JSON.parse(cached))
-        } catch (err) {
-          console.error("Failed to parse tweakInfo cache", err)
-        }
-      }
-
-      invoke({ channel: "tweaks:fetch" })
-        .then((tweaks) => {
-          setTweakInfo(tweaks)
-          localStorage.setItem("sparkle:tweakInfo", JSON.stringify(tweaks))
-        })
-        .catch((err) => {
-          console.error("Error fetching tweak info:", err)
-        })
-    })
-
-    return () => cancelIdleCallback(idleHandle)
-  }, [])
-
-  useEffect(() => {
-    const idleHandle = requestIdleCallback(() => {
-      fetchActiveTweaks()
-    })
-
-    return () => cancelIdleCallback(idleHandle)
-  }, [])
-
-  const formatBytes = (bytes) => {
-    if (bytes === 0 || !bytes) return "0 GB"
-    return (bytes / 1024 / 1024 / 1024).toFixed(2) + " GB"
-  }
-
-  if (loading) {
-    return (
-      <RootDiv>
-        <div className="flex items-center justify-center h-64 flex-col gap-5">
-          <div className="">
-            <div
-              className="animate-spin inline-block w-6 h-6 border-[3px] border-current border-t-transparent text-sparkle-primary rounded-full ml-3"
-              role="status"
-              aria-label="loading"
-            ></div>
-          </div>
-          <div className="text-sparkle-text-secondary">Loading system information...</div>
-          <p className="text-sm text-sparkle-primary">
-            You may use other parts of sparkle while this loads
-          </p>
-        </div>
-      </RootDiv>
-    )
-  }
+  const goToTweaks = () => router("tweaks")
+  const goToUtilities = () => router("utilities")
+  const goToApps = () => router("apps")
 
   return (
     <RootDiv>
-      <div className="max-w-[1800px] mx-auto ">
-        <Greeting />
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <InfoCard
-            icon={Cpu}
-            iconBgColor="bg-blue-500/10"
-            iconColor="text-blue-500"
-            title="CPU"
-            subtitle="Processor Information"
-            items={[
-              { label: "Model", value: systemInfo?.cpu_model || "Unknown" },
-              { label: "Cores", value: `${systemInfo?.cpu_cores || "0"} Cores` },
-            ]}
-          />
-
-          <InfoCard
-            icon={Gpu}
-            iconBgColor="bg-teal-500/10"
-            iconColor="text-teal-500"
-            title="GPU"
-            subtitle="Graphics Information"
-            items={
-              systemInfo?.hasGPU
-                ? [
-                    { label: "Model", value: systemInfo?.gpu_model || "Unknown" },
-                    { label: "VRAM", value: systemInfo?.vram || "Unknown" },
-                  ]
-                : [
-                    { label: "Model", value: systemInfo?.integrated_gpu || "Unknown" },
-                    { label: "Type", value: "Integrated" },
-                  ]
-            }
-          />
-
-          <InfoCard
-            icon={MemoryStick}
-            iconBgColor="bg-purple-500/10"
-            iconColor="text-purple-500"
-            title="Memory"
-            subtitle="RAM Information"
-            items={[
-              { label: "Total Memory", value: formatBytes(systemInfo?.memory_total) },
-              { label: "Type", value: systemInfo?.memory_type || "Unknown" },
-            ]}
-          />
-
-          <InfoCard
-            icon={MonitorCog}
-            iconBgColor="bg-red-500/10"
-            iconColor="text-red-500"
-            title="System"
-            subtitle="OS Information"
-            items={[
-              { label: "Operating System", value: systemInfo?.os || "Unknown" },
-              { label: "Version", value: systemInfo?.os_version || "Unknown" },
-            ]}
-          />
-
-          <InfoCard
-            icon={HardDrive}
-            iconBgColor="bg-orange-500/10"
-            iconColor="text-orange-500"
-            title="Storage"
-            subtitle="Disk Information"
-            items={[
-              { label: "Primary Disk", value: systemInfo?.disk_model || "Unknown" },
-              { label: "Total Space", value: systemInfo?.disk_size || "Unknown" },
-            ]}
-          />
-
-          <InfoCard
-            icon={Wrench}
-            iconBgColor="bg-green-500/10"
-            iconColor="text-green-500"
-            title="Tweaks"
-            subtitle="Applied Tweaks"
-            items={[
-              { label: "Available Tweaks", value: `${tweakInfo?.length || 0} Tweaks` },
-              { label: "Active Tweaks", value: `${activeTweaks.length || 0} Active` },
-            ]}
-          />
-        </div>
-        <Card className="bg-sparkle-card backdrop-blur-xs rounded-xl border border-sparkle-border hover:shadow-xs overflow-hidden p-3 w-full mt-4 flex gap-4 items-center">
-          <div className="p-3 bg-green-500/10 rounded-lg items-center justify-center text-center">
-            <Wrench className="text-green-500" size={24} />
+      <div className="max-w-450 mx-auto px-4">
+        <div className="text-center py-16">
+          <h1 className="text-5xl font-bold text-sparkle-text mb-4 tracking-tight">
+            Welcome to Sparkle
+          </h1>
+          <p className="text-lg text-sparkle-text-secondary mb-8 max-w-md mx-auto">
+            The ultimate tool to debloat and optimize Windows, and enhance your privacy.
+          </p>
+          <div className="flex justify-center gap-3">
+            <Button onClick={goToTweaks}>
+              <Wrench size={16} className="mr-2" /> Browse Tweaks
+            </Button>
+            <Button onClick={goToUtilities}>
+              <Box size={16} className="mr-2" /> Go To Utilities
+            </Button>
+            <Button onClick={goToApps}>
+              <LayoutGrid size={16} className="mr-2" /> Go To Apps
+            </Button>
           </div>
-          <div>
-            <h1 className="font-medium text-sparkle-text">PC Running slow?</h1>
-            <p className="text-sparkle-text-secondary">
-              Try Using Tweaks to improve system performance and privacy.
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <Card className="bg-sparkle-card border border-sparkle-border rounded-xl p-5 flex flex-col gap-3 hover:border-sparkle-primary/40 transition-colors">
+            <div className="p-2.5 bg-blue-500/10 rounded-lg w-fit">
+              <Cpu className="text-blue-400" size={20} />
+            </div>
+            <div>
+              <h3 className="font-semibold text-sparkle-text text-sm">Performance Tweaks</h3>
+              <p className="text-sparkle-text-secondary text-xs mt-1 leading-relaxed">
+                Speed up boot times on low end systems and reduce latency
+              </p>
+            </div>
+          </Card>
+
+          <Card className="bg-sparkle-card border border-sparkle-border rounded-xl p-5 flex flex-col gap-3 hover:border-sparkle-primary/40 transition-colors">
+            <div className="p-2.5 bg-green-500/10 rounded-lg w-fit">
+              <Shield className="text-green-400" size={20} />
+            </div>
+            <div>
+              <h3 className="font-semibold text-sparkle-text text-sm">Privacy Controls</h3>
+              <p className="text-sparkle-text-secondary text-xs mt-1 leading-relaxed">
+                Disable telemetry and lock down Windows data collection settings.
+              </p>
+            </div>
+          </Card>
+
+          <Card className="bg-sparkle-card border border-sparkle-border rounded-xl p-5 flex flex-col gap-3 hover:border-sparkle-primary/40 transition-colors">
+            <div className="p-2.5 bg-purple-500/10 rounded-lg w-fit">
+              <Wrench className="text-purple-400" size={20} />
+            </div>
+            <div>
+              <h3 className="font-semibold text-sparkle-text text-sm">Customization</h3>
+              <p className="text-sparkle-text-secondary text-xs mt-1 leading-relaxed">
+                Personalize the Windows experience to match your workflow and preferences.
+              </p>
+            </div>
+          </Card>
+        </div>
+
+        {/* CTA Banner */}
+        <Card className="bg-sparkle-card border border-sparkle-border rounded-xl p-4 w-full mb-6 flex gap-4 items-center hover:border-green-500/30 transition-colors">
+          <div className="p-3 bg-green-500/10 rounded-lg shrink-0">
+            <Zap className="text-green-500" size={22} />
+          </div>
+          <div className="min-w-0">
+            <h2 className="font-semibold text-sparkle-text text-sm">PC Running Slow?</h2>
+            <p className="text-sparkle-text-secondary text-xs mt-0.5">
+              Apply recommended tweaks to improve performance and privacy in minutes.
             </p>
           </div>
-          <div className="ml-auto">
-            <Button variant="outline" className="flex items-center gap-2" onClick={goToTweaks}>
-              <Zap size={18} /> Visit Tweaks
+          <div className="ml-auto shrink-0">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2 text-sm"
+              onClick={goToTweaks}
+            >
+              <Wrench size={15} /> Open Tweaks
             </Button>
           </div>
         </Card>
-        <p className="text-xs text-sparkle-text-secondary text-center mt-4">
-          {usingCache ? "Loading latest system data..." : ""}
-        </p>
+
+        {/* Footer note */}
+        <div className="text-center text-xs text-sparkle-text-secondary pb-6">
+          <a
+            href="https://github.com/anomalyco/sparkle/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 hover:text-sparkle-primary transition-colors"
+          >
+            <ExternalLink size={12} />
+            Why was system info removed?
+          </a>
+        </div>
       </div>
     </RootDiv>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,31 +1,5 @@
 import React from "react"
 
-export interface SystemInfo {
-  platform?: string
-  arch?: string
-  version?: string
-  hostname?: string
-  userInfo?: {
-    username: string
-    homedir: string
-  }
-  cpu_model?: string
-  cpu_cores?: number
-  cpu_threads?: number
-  gpu_model?: string
-  vram?: string
-  hasGPU?: boolean
-  isNvidia?: boolean
-  integrated_gpu?: string
-  hasIntegratedGPU?: boolean
-  memory_total?: number
-  memory_type?: string
-  os?: string
-  os_version?: string
-  disk_model?: string
-  disk_size?: string
-}
-
 export interface Tweak {
   id: string
   name: string
@@ -86,7 +60,6 @@ export interface ElectronAPI {
   minimizeWindow: () => void
   maximizeWindow: () => void
   closeWindow: () => void
-  getSystemInfo: () => Promise<SystemInfo>
   applyTweak: (tweakId: string) => Promise<boolean>
   unapplyTweak: (tweakId: string) => Promise<boolean>
   getTweaks: () => Promise<Tweak[]>


### PR DESCRIPTION
## Removes the Dashboard page and replaces it with `home` which simply tells user to go to other pages.

### Why

The `systeminformation` package was being called on the dashboard page to display system info. under the hood, it was causing CPU spikes and load times of up to 5 minutes for some users on low end PCs before that page was usable. And the whole point of sparkle is to debloat and optimize your Windows PC.

I've been considering introducing another programming language to help with these tasks such as C# or go, but at the moment I am unsure.

### Changes

- Removed All System info from `Home.tsx`, `system.ts`
- Updated homepage with feature highlight cards and page links

### What I Did Not Change
I have decided to not remove the `systeminfomation` package at this time since Sparkles GPU detection feature relies on this package, For your information, Sparkle uses this for allow or dissallowing users to apply thinks like [HAGS ](https://docs.getsparkle.net/tweaks/enable-hags/)or [NVIDIA](https://docs.getsparkle.net/tweaks/optimize-nvidia-settings/) Tweaks. Like I said earlier I may introduce another language to help with these tasks and keep the Electron part lightweight and only for the gui.

This may return in the future. And I'm not sure if I want to merge this.