### PR TITLE
fix: correct return type annotation in getActiveTweaks()

### DIFF
--- a/src/main/tweakHandler.ts
+++ b/src/main/tweakHandler.ts
@@ -252,20 +252,20 @@ export const setupTweaksHandlers = (): void => {
     return NvidiaProfileInspector()
   })
 
-  ipcMain.handle("tweak:active", (): Record<string, boolean> | {} => {
+  ipcMain.handle("tweak:active", (): string[] => {
     return getActiveTweaks()
   })
   console.log("[Sparkle main/tweakHandler.ts]: Tweak handlers setup complete")
 }
 
-const getActiveTweaks = (): Record<string, boolean> | {} => {
+const getActiveTweaks = (): string[] => {
   try {
     const data = fsSync.readFileSync(tweaksStatePath, "utf8")
     const parsed = JSON.parse(data)
     return Object.keys(parsed).filter((key) => parsed[key])
   } catch (error) {
     console.error("Error loading tweak states:", error)
-    return {}
+    return []
   }
 }
 


### PR DESCRIPTION
## Summary
- `getActiveTweaks()` returns `string[]` (from `Object.keys().filter()`) but the type annotation declares `Record<string, boolean> | {}`
- The caller in `Home.tsx` uses `.length` on the result, confirming it expects an array
- Fixed the return type to `string[]` and the error fallback from `{}` to `[]`

## Changes
| File | Change |
|------|--------|
| `src/main/tweakHandler.ts` | Return type `Record<string, boolean> \| {}` → `string[]` |
| `src/main/tweakHandler.ts` | IPC handler type updated to match |
| `src/main/tweakHandler.ts` | Error fallback `{}` → `[]` |

## Test plan
- [ ] Verify active tweaks count displays correctly in Home dashboard
- [ ] Verify tweaks persist and load correctly after restart
- [ ] Run TypeScript compiler — confirm no type errors