### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ cd Sparkle</code></pre>
 
 ## Star History
 
-<a href="https://www.star-history.com/#Parcoil/Sparkle&Date">
+<a href="https://star-history.dera.page/#Parcoil/Sparkle&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Parcoil/Sparkle&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Parcoil/Sparkle&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Parcoil/Sparkle&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Parcoil/Sparkle&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Parcoil/Sparkle&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Parcoil/Sparkle&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the bottom of the README is broken due to GitHub stargazer API restrictions. This change points the chart to the star-history.dera.page endpoint, which uses an alternative data source that requires no API token, restoring the chart without any manual setup.